### PR TITLE
Dependency and Support Bump

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "description": "This module provides providers for Puppet base types using the Augeas configuration API library.",
   "dependencies": [
     {
-      "name": "voxpupuli/augeasproviders_core",
+      "name": "puppet/augeasproviders_core",
       "version_requirement": ">=3.0.0 < 4.0.0"
     }
   ],

--- a/metadata.json
+++ b/metadata.json
@@ -28,22 +28,61 @@
         "14.04",
         "16.04",
         "18.04",
-        "18.10"
+        "18.10",
+        "20.04"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
-        "7"
+        "7",
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7",
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "35",
+        "36"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "6",
+        "7",
+        "8"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.1.0 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ]
 }


### PR DESCRIPTION
* Bumped `herculesteam/augeasproviders_core` to < 4.0.0
* Bumped puppet version to < 8.0.0
* Updated OS support to latest known releases
* Added support for CentOS, Rocky, Alma, Oracle, and Fedora
