### PR TITLE
Correct name of the augeasproviders_core dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "description": "This module provides providers for Puppet base types using the Augeas configuration API library.",
   "dependencies": [
     {
-      "name": "voxpupuli/augeasproviders_core",
+      "name": "puppet/augeasproviders_core",
       "version_requirement": ">=3.0.0 < 4.0.0"
     }
   ],


### PR DESCRIPTION
Vox Pupuli uses the puppet namespace, not voxpupuli. Introduced in 77c3578084d75ebe198067e10c87cb3ab7054816.

Fixes #12